### PR TITLE
Removed hardcoded path to theme

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,7 +6,7 @@
 	
 	<p class="cc">This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.</p>
 
-	<p><a href="http://simplebits.com" id="sb"><img src="/wp-content/themes/pears/images/sb-black.png" /></a></p>
+	<p><a href="http://simplebits.com" id="sb"><img src="<?php echo get_template_directory_uri();?>/images/sb-black.png" /></a></p>
 </div> <!-- /footer -->
 
 <!-- jQuery -->

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 <body <?php body_class(); ?>>
 
 <header role="banner" class="group">
-	<a href="<?php echo site_url(); ?>" id="logo">
+	<a href="<?php echo home_url(); ?>" id="logo">
 		Pears <em>are common patterns of markup &amp; style</em>
 	</a>
 </header>

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 <body <?php body_class(); ?>>
 
 <header role="banner" class="group">
-	<a href="/" id="logo">
+	<a href="<?php echo site_url(); ?>" id="logo">
 		Pears <em>are common patterns of markup &amp; style</em>
 	</a>
 </header>

--- a/loop-single.php
+++ b/loop-single.php
@@ -33,14 +33,14 @@
 		
 		<div class="group">
 			<div id="markup" class="mod">
-				<h3 class="label">HTML</h3> <a href="#" class="clip" title="select code for copying"><img src="/wp-content/themes/pears/images/icon-copy.png" alt="copy" /></a>
+				<h3 class="label">HTML</h3> <a href="#" class="clip" title="select code for copying"><img src="<?php echo get_template_directory_uri();?>/images/icon-copy.png" alt="copy" /></a>
 				<textarea class="mod-ta">
 <?php $key="html"; echo get_post_meta($post->ID, $key, true); ?>			
 				</textarea>
 			</div>
 			
 			<div id="style" class="mod">
-				<h3 class="label">CSS</h3> <a href="#" class="clip" title="select code for copying"><img src="/wp-content/themes/pears/images/icon-copy.png" alt="copy" /></a>
+				<h3 class="label">CSS</h3> <a href="#" class="clip" title="select code for copying"><img src="<?php echo get_template_directory_uri();?>/images/icon-copy.png" alt="copy" /></a>
 				<textarea id="css-code" class="mod-ta">
 <?php $key="css"; echo get_post_meta($post->ID, $key, true); ?>
 				</textarea>


### PR DESCRIPTION
Hardcoded paths to the theme were causing images to not load when the WordPress installation was in a subdirectory. I replaced all instances of /wp-content/themes/pear/ with the with more dynamic `get_template_directory_uri();`

I also replaced the link to the home page in the logo with the more dynamic `echo site_url();`
