### PR TITLE
Dynamic Path for LogoHeader + copy icon image

### DIFF
--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 <body <?php body_class(); ?>>
 
 <header role="banner" class="group">
-	<a href="/" id="logo">
+	<a href="<?php bloginfo('siteurl'); ?>/" id="logo">
 		Pears <em>are common patterns of markup &amp; style</em>
 	</a>
 </header>

--- a/loop-single.php
+++ b/loop-single.php
@@ -33,14 +33,14 @@
 		
 		<div class="group">
 			<div id="markup" class="mod">
-				<h3 class="label">HTML</h3> <a href="#" class="clip" title="select code for copying"><img src="/wp-content/themes/pears/images/icon-copy.png" alt="copy" /></a>
+				<h3 class="label">HTML</h3> <a href="#" class="clip" title="select code for copying"><img src="<?php bloginfo('template_directory'); ?>/images/icon-copy.png" alt="copy" /></a>
 				<textarea class="mod-ta">
 <?php $key="html"; echo get_post_meta($post->ID, $key, true); ?>			
 				</textarea>
 			</div>
 			
 			<div id="style" class="mod">
-				<h3 class="label">CSS</h3> <a href="#" class="clip" title="select code for copying"><img src="/wp-content/themes/pears/images/icon-copy.png" alt="copy" /></a>
+				<h3 class="label">CSS</h3> <a href="#" class="clip" title="select code for copying"><img src="<?php bloginfo('template_directory'); ?>/images/icon-copy.png" alt="copy" /></a>
 				<textarea id="css-code" class="mod-ta">
 <?php $key="css"; echo get_post_meta($post->ID, $key, true); ?>
 				</textarea>


### PR DESCRIPTION
1. The copy icon is broken (if you didn't with theme name "pear" or when it's not installed in first level).
   Therefore, i made the image path dynamically according to the theme path.
2. Header logo and text link is not dynamic (will not work wordpress install in sub folder using custom domain name), therefore i use wp standard variable to replace it.
