### PR TITLE
outline: none removed and focus established

### DIFF
--- a/css/screen.less
+++ b/css/screen.less
@@ -110,11 +110,14 @@ body {
 a:link, a:visited {
 	color: @link-color;
 	text-decoration: none;
-	outline: none;
 	}
 a:hover {
 	color: @link-hover-color;
 	}
+a:focus {
+	outline: solid 2px #A1CF32;
+	overflow: hidden;
+}
 
 /* page structure 
 --------------------------------------------- */

--- a/css/screen.less
+++ b/css/screen.less
@@ -93,9 +93,6 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 	}
-:focus {
-	outline: none;
-	}
 
 /* general styles 
 --------------------------------------------- */


### PR DESCRIPTION
Hi Dan,

I just made small commit to my fork, to focus display on your Pears project. As I want to use Pears to show some accessibility snippets I need and want to improve some small accessibility details. You used reset and doubled it by outline: none to links. So I put it back and made it greenish to be nice with your great layout. Check this out, hope you like. If you don't maybe you could just remove outline: none from everywhere, to leave default focus enabled?

All the best!
Dominik
