### PR TITLE
CSS Preprocessors

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3,7 +3,7 @@
 * Pears functions and customizations
 **/
 
-// Setup for CSS STYLE_TYPEs
+// Setup for CSS preprocessors
 // Possible options here:
 // css, sass, scss, less, stylus
 define("STYLE_TYPE", "scss");

--- a/loop-single.php
+++ b/loop-single.php
@@ -18,7 +18,10 @@
 <?php if ( have_posts() ) while ( have_posts() ) : the_post(); ?>
 
 <style id="s" type="text/css">
-<?php $key="css"; echo get_post_meta($post->ID, $key, true); ?>
+<?php 
+// convert SCSS to CSS
+echo convertScss("http://alloy.divshot.com/compile", get_post_meta($post->ID, STYLE_TYPE, true));
+?>
 </style>
 
 <div id="pattern" class="mod group">
@@ -40,9 +43,9 @@
 			</div>
 			
 			<div id="style" class="mod">
-				<h3 class="label">CSS</h3> <a href="#" class="clip" title="select code for copying"><img src="<?php bloginfo('template_directory'); ?>/images/icon-copy.png" alt="copy" /></a>
-				<textarea id="css-code" class="mod-ta">
-<?php $key="css"; echo get_post_meta($post->ID, $key, true); ?>
+				<h3 class="label"><?php echo STYLE_TYPE ?></h3> <a href="#" class="clip" title="select code for copying"><img src="<?php bloginfo('template_directory'); ?>/images/icon-copy.png" alt="copy" /></a>
+				<textarea id="csss-code" class="mod-ta">
+<?php echo get_post_meta($post->ID, STYLE_TYPE, true); ?>
 				</textarea>
 			</div>
 		</div>


### PR DESCRIPTION
I was looking for a way to use Sass snippets rather than CSS snippets so I did some digging and discovered a very useful API for compiling CSS using preprocessors. (http://divshot.com/alloy)

I've modified the functions.php file to include the following configurations:

``` php
// Setup for CSS preprocessors
// Possible options here:
// css, sass, scss, less, stylus
define("STYLE_TYPE", "scss");
define("COMPASS", true); // if you're using Sass/scss, will you be using compass?
```

Simply update those to use your CSS preprocessor of choice.

Hopefully this will be useful to others.
